### PR TITLE
fix issue #3

### DIFF
--- a/src/main/java/com/duolingo/open/rtlviewpager/RtlViewPager.java
+++ b/src/main/java/com/duolingo/open/rtlviewpager/RtlViewPager.java
@@ -173,8 +173,8 @@ public class RtlViewPager extends ViewPager {
         }
 
         SavedState ss = (SavedState) state;
-        super.onRestoreInstanceState(ss.mViewPagerSavedState);
         mLayoutDirection = ss.mLayoutDirection;
+        super.onRestoreInstanceState(ss.mViewPagerSavedState);
     }
 
     @Override


### PR DESCRIPTION
considering #3 
restoring the layout direction in onRestoreInstanceState() before calling super implementation
since super implementation calls setCurrentItem() which in turn notifies the listeners so editing this allows us to use the correct saved