### PR TITLE
Memory optimization

### DIFF
--- a/src/main/java/com/duolingo/open/rtlviewpager/RtlViewPager.java
+++ b/src/main/java/com/duolingo/open/rtlviewpager/RtlViewPager.java
@@ -198,6 +198,12 @@ public class RtlViewPager extends ViewPager {
     }
 
     @Override
+    public void clearOnPageChangeListeners() {
+        super.clearOnPageChangeListeners();
+        mPageChangeListeners.clear();
+    }
+
+    @Override
     protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
         if (MeasureSpec.getMode(heightMeasureSpec) == MeasureSpec.UNSPECIFIED) {
             int height = 0;

--- a/src/main/java/com/duolingo/open/rtlviewpager/RtlViewPager.java
+++ b/src/main/java/com/duolingo/open/rtlviewpager/RtlViewPager.java
@@ -191,7 +191,10 @@ public class RtlViewPager extends ViewPager {
 
     @Override
     public void removeOnPageChangeListener(OnPageChangeListener listener) {
-        super.removeOnPageChangeListener(mPageChangeListeners.get(listener));
+        ReversingOnPageChangeListener reverseListener = mPageChangeListeners.remove(listener);
+        if (reverseListener != null) {
+            super.removeOnPageChangeListener(reverseListener);
+        }
     }
 
     @Override


### PR DESCRIPTION
## What I did
Probably developers won't add multiple `addOnPageChangeListener` but if they do. It will be great if we handle mPageChangeListeners accordingly when we remove/clear `OnPageChangeListener`

- Remove `mPageChangeListeners` item when `removeOnPageChangeListener(OnPageChangeListener listener)` is called
- `clearOnPageChangeListeners()` to clear  `mPageChangeListeners`